### PR TITLE
passing the coordinates of the clicked tile to tensorflow

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -114,6 +114,7 @@ export class App extends React.Component<AppProps, AppState> {
     public activateCell(row: number, col: number, data: number): void {
         const { grid } = TensorFlowService.cloneGrid(this.state.grid);
         const update = { grid, playerPos: this.state.playerPos };
+
         if (
             this.state.selectedSidebarButtonName ===
             SidebarButtonNames.PENCIL_BUTTON
@@ -137,7 +138,7 @@ export class App extends React.Component<AppProps, AppState> {
         }
         update.grid = grid;
         this.setState(update);
-        this.updateGhostLayer(grid, this.state.gridSize);
+        this.updateGhostLayer(grid, this.state.gridSize, undefined, [row, col]);
     }
 
     public clearStage() {
@@ -172,7 +173,8 @@ export class App extends React.Component<AppProps, AppState> {
     public async updateGhostLayer(
         nextGrid: number[][],
         nextSize: [number, number],
-        repName?: RepresentationName
+        repName?: RepresentationName,
+        clickedTile?: [number, number]
     ) {
         // Skip TF updates on 0 grid
         if (!nextSize[0] || !nextSize[1]) {
@@ -194,7 +196,8 @@ export class App extends React.Component<AppProps, AppState> {
                 .predictAndDraw(
                     this.state.grid,
                     this.state.gridSize,
-                    repName
+                    repName,
+                    clickedTile
                     // TODO: add offset?
                 )
                 .then(({ suggestedGrid, targets }: IPredictionResult) => {

--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -28,6 +28,7 @@ export function Toolbar({
                     gridSize={gridSize}
                 />
             )}
+            {<div>Foo</div>}
         </div>
     );
 }

--- a/src/services/TensorFlow/index.ts
+++ b/src/services/TensorFlow/index.ts
@@ -118,21 +118,6 @@ export class TensorFlowService {
             });
     }
 
-    public static tensorFlowHelloWorld() {
-        // // Initiailize a demo tensor
-        // const a = tf.tensor([
-        //     [1, 2],
-        //     [3, 4],
-        // ]);
-        // console.log("a shape:", a.shape);
-        // a.print();
-        // // Test model
-        // fetchModel().then(async (modelResp) => {
-        //     model = modelResp;
-        //     // game = setInterval(predictAndDraw, 50);
-        // });
-    }
-
     async fetchModels(): Promise<ModelsDictionary> {
         const fetchedModels: ModelsDictionary = {};
         for (let key in MODEL_URLS) {
@@ -260,8 +245,14 @@ export class TensorFlowService {
     public async predictAndDraw(
         gridState: number[][],
         gridSize: [number, number],
-        repName: RepresentationName
+        repName: RepresentationName,
+        clickedTileCoords?: [number, number]
     ): Promise<IPredictionResult> {
+        // Log the clicked tile coordinates
+        if (clickedTileCoords) {
+            console.log("clicked tile:", clickedTileCoords);
+        }
+
         let model: TSModelType | undefined | null = this.models[repName];
         if (!model) {
             console.log("Model unavailable! Fetching...");
@@ -314,6 +305,8 @@ export class TensorFlowService {
                         .cast(preResp, "int32")
                         .flatten()
                         .argMax();
+                    console.log("Raw Response:");
+                    preResp.print();
                     const arr = await intResult.array();
                     console.log("Output: ", arr);
                     const parsedOutput = this.parseModelOutput(arr, repName);


### PR DESCRIPTION
# Clicked Tile Position

## Description

- Adding a `[number, number]` tuple to the `predictAndDraw()` function which denotes the coordinates of the tile the user clicked.

## Branch Build Link

https://deploy-preview-9--pcgrl-editor.netlify.app/

## Screenshot
![Screen Shot 2020-04-25 at 4 50 20 PM](https://user-images.githubusercontent.com/2551722/80290669-e50ab000-8714-11ea-88f4-c45ab6f4fb56.png)
